### PR TITLE
Fix Account Header Overlap

### DIFF
--- a/hodlwallet/src/ViewControllers/AccountViewController.swift
+++ b/hodlwallet/src/ViewControllers/AccountViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import BRCore
 import MachO
 
-let accountHeaderHeight: CGFloat = 136.0
+let accountHeaderHeight: CGFloat = 150.0
 private let transactionsLoadingViewHeightConstant: CGFloat = 48.0
 
 class AccountViewController : UIViewController, Subscriber {
@@ -131,7 +131,7 @@ class AccountViewController : UIViewController, Subscriber {
     }
 
     private func addConstraints() {
-        headerContainer.constrainTopCorners(sidePadding: 0, topPadding: 15)
+        headerContainer.constrainTopCorners(sidePadding: 0, topPadding: 0)
         headerContainer.constrain([
             headerContainer.constraint(.height, constant: accountHeaderHeight) ])
         headerView.constrain(toSuperviewEdges: nil)

--- a/hodlwallet/src/Views/AccountHeaderView.swift
+++ b/hodlwallet/src/Views/AccountHeaderView.swift
@@ -209,7 +209,7 @@ class AccountHeaderView : UIView, Subscriber {
 
         logo.constrain([
             logo.leadingAnchor.constraint(equalTo: leadingAnchor, constant: C.padding[2]),
-            logo.topAnchor.constraint(equalTo: topAnchor, constant: 15.0),
+            logo.topAnchor.constraint(equalTo: topAnchor, constant: 30.0),
             logo.heightAnchor.constraint(equalTo: logo.widthAnchor, multiplier: C.Sizes.logoAspectRatio),
             logo.widthAnchor.constraint(equalTo: widthAnchor, multiplier: logoWidth) ])
         modeLabel.constrain([


### PR DESCRIPTION
This should keep transactions from appearing at the top of the screen.