### PR TITLE
Fix unsafe raw pointer memory error, Swift is weird

### DIFF
--- a/hodlwallet/src/BRCore.swift
+++ b/hodlwallet/src/BRCore.swift
@@ -255,7 +255,13 @@ extension BRTxInput {
 
 extension BRTxOutput {
     var swiftAddress: String {
-        get { return String(cString: UnsafeRawPointer([self.address]).assumingMemoryBound(to: CChar.self)) }
+        get {
+            return withUnsafePointer(to: self.address) {
+                $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout.size(ofValue: self.address)) {
+                    String(cString: $0)
+                }
+            }
+        }
         set { BRTxOutputSetAddress(&self, newValue) }
     }
     


### PR DESCRIPTION
Thanks to @MsBarber with the assist reading the docs of Swift and questions on Stack Overflow, you think you know pointer math until you deal with this language lol