### PR TITLE
Fix problem of HODL using fallback url instead of precio rates api

### DIFF
--- a/MessagesExtension/Info.plist
+++ b/MessagesExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/NotificationServiceExtension/Info.plist
+++ b/NotificationServiceExtension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/TodayExtension/Info.plist
+++ b/TodayExtension/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionMainStoryboard</key>

--- a/hodlwallet WatchKit App/Info.plist
+++ b/hodlwallet WatchKit App/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/hodlwallet WatchKit Extension/Info.plist
+++ b/hodlwallet WatchKit Extension/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>CLKComplicationPrincipalClass</key>
 	<string>$(PRODUCT_MODULE_NAME).ComplicationController</string>
 	<key>CLKComplicationSupportedFamilies</key>

--- a/hodlwallet/BRAPIClient+Wallet.swift
+++ b/hodlwallet/BRAPIClient+Wallet.swift
@@ -77,9 +77,8 @@ extension BRAPIClient {
                     }
                     handler(array.flatMap { Rate(data: $0) }, nil)
                 } else {
-                    guard let dict = parsedData as? [String: Any],
-                        let array = dict["body"] as? [Any] else {
-                            return self.exchangeRates(isFallback: true, handler)
+                    guard let array = parsedData as? [Any] else {
+                        return self.exchangeRates(isFallback: true, handler)
                     }
                     handler(array.flatMap { Rate(data: $0) }, nil)
                 }

--- a/hodlwallet/Info.plist
+++ b/hodlwallet/Info.plist
@@ -56,7 +56,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.9</string>
+	<string>3.1.10</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>
@@ -91,7 +91,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>19</string>
+	<string>20</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
This was making the user go to the fallback URL instead, which was not intended, this change brings a lot more price accuracy for our US users.